### PR TITLE
fix: don't require dimensions for 1D or 2D arrays

### DIFF
--- a/test/minzinc_data_test.exs
+++ b/test/minzinc_data_test.exs
@@ -1,0 +1,17 @@
+defmodule MinizincDataTest do
+  use ExUnit.Case
+
+  describe "elixir_to_dzn/1" do
+    test "can create an array of arrays without specifying the bases" do
+      array = [
+        [1, 2, 3],
+        [3, 4, 5]
+      ]
+
+      expected = "[|1, 2, 3 | 3, 4, 5|]"
+      actual = MinizincData.elixir_to_dzn(array)
+
+      assert expected == actual
+    end
+  end
+end

--- a/test/solverl_test.exs
+++ b/test/solverl_test.exs
@@ -277,7 +277,7 @@ defmodule SolverlTest do
       MapSet.new()
     ]
 
-    expected = "array1d(1..3,[{1, 2}, {3}, {}])"
+    expected = "[{1, 2}, {3}, {}]"
     actual = MinizincData.elixir_to_dzn(array)
 
     assert expected == actual


### PR DESCRIPTION
Avoids issue with enum dimensions. Here's a small sample MZN:

```
enum keys;
array[keys] of bool: truth_values;

constraint true
solve satisfy;
```
and with Elixir data:
```elixir
%{
  keys: {:a, :b, :c},
  truth_values: [true, false, true]
}
```
The earlier generated DZN looked like `array1d(1..3, [true, false, true])` which MiniZinc rejected. `[| true, false, true|]` is properly coerced to the enum keys.
