### PR TITLE
fix: include `module()` as a type for `solution_handler`

### DIFF
--- a/lib/minizinc_solver.ex
+++ b/lib/minizinc_solver.ex
@@ -11,7 +11,7 @@ defmodule MinizincSolver do
           | {:solver, binary()}
           | {:checker, MinizincModel.mzn_model()}
           | {:time_limit, integer()}
-          | {:solution_handler, function()}
+          | {:solution_handler, function() | module()}
           | {:solution_timeout, timeout()}
           | {:fzn_timeout, timeout()}
           | {:sync_to, pid() | nil}


### PR DESCRIPTION
It's described this way in the [documentation](https://hexdocs.pm/solverl/readme.html#solver-options):

> Module or function that controls processing of solutions and/or metadata.